### PR TITLE
fix: updating prometheus credentials

### DIFF
--- a/infra/prometheus-operator.yaml
+++ b/infra/prometheus-operator.yaml
@@ -14,8 +14,8 @@ spec:
 ---
 apiVersion: v1
 data:
-  admin-password: a2F5dHUtZ2YtcGFzcwo=
-  admin-user: a2F5dHUtZ2YK
+  admin-password: a2F5dHUtZ2YtcGFzcw==
+  admin-user: a2F5dHUtZ2Y=
   ldap-toml: ""
 kind: Secret
 metadata:


### PR DESCRIPTION
Unable to log in to prom-grafana UI. Both username and password have a newline character at the end.


<img width="607" alt="Screenshot 2024-09-09 at 13 52 50" src="https://github.com/user-attachments/assets/4409667b-52cf-45c0-9e91-7e9c3d70878d">


This PR fixes the credentials. 